### PR TITLE
Utilise le fork govpf de musl-locales

### DIFF
--- a/8/jdk/alpine/Dockerfile
+++ b/8/jdk/alpine/Dockerfile
@@ -16,8 +16,8 @@ ENV LC_ALL fr_FR.utf8
 ENV MUSL_LOCALE_DEPS cmake make musl-dev gcc gettext-dev libintl
 ENV MUSL_LOCPATH /usr/share/i18n/locales/musl
 RUN apk add --no-cache $MUSL_LOCALE_DEPS \
-    && wget https://gitlab.com/jonathan.pigree1/musl-locales/-/archive/master/musl-locales-master.zip \
-    && unzip musl-locales-master.zip \
+    && wget https://github.com/govpf/musl-locales/archive/master.zip \
+    && unzip master.zip \
     && cd musl-locales-master \
     && cmake -DLOCALE_PROFILE=OFF -D CMAKE_INSTALL_PREFIX:PATH=/usr . && make && make install \
     && cd .. && rm -r musl-locales-master

--- a/8/jre/alpine/Dockerfile
+++ b/8/jre/alpine/Dockerfile
@@ -16,8 +16,8 @@ ENV LC_ALL fr_FR.utf8
 ENV MUSL_LOCALE_DEPS cmake make musl-dev gcc gettext-dev libintl
 ENV MUSL_LOCPATH /usr/share/i18n/locales/musl
 RUN apk add --no-cache $MUSL_LOCALE_DEPS \
-    && wget https://gitlab.com/jonathan.pigree1/musl-locales/-/archive/master/musl-locales-master.zip \
-    && unzip musl-locales-master.zip \
+    && wget https://github.com/govpf/musl-locales/archive/master.zip \
+    && unzip master.zip \
     && cd musl-locales-master \
     && cmake -DLOCALE_PROFILE=OFF -D CMAKE_INSTALL_PREFIX:PATH=/usr . && make && make install \
     && cd .. && rm -r musl-locales-master


### PR DESCRIPTION
En remplacement de mon fork personnel.

_musl-locales_ est disponible dans les dépôts de la distribution Alpine **3.12** minimum.
Cependant, les images OpenJDK sur lesquelles sont basées les notres utilisent Alpine **3.9**.

Du coup, il nous faut continuer à installer les locales à partir du code source.